### PR TITLE
매치 승자처리 기능 구현

### DIFF
--- a/togetherHana/src/main/java/com/togetherhana/exception/ErrorType.java
+++ b/togetherHana/src/main/java/com/togetherhana/exception/ErrorType.java
@@ -25,6 +25,7 @@ public enum ErrorType {
 	 * 401 UNAUTHROZIED
 	 */
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않았습니다."),
+	LEADER_PRIVILEGES_REQUIRED(HttpStatus.UNAUTHORIZED, "총무 권한이 필요합니다."),
 
 	/**
 	 * 404 NOT FOUND

--- a/togetherHana/src/main/java/com/togetherhana/game/controller/GameController.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/controller/GameController.java
@@ -1,17 +1,13 @@
 package com.togetherhana.game.controller;
 
-import java.util.List;
-
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.togetherhana.base.BaseResponse;
 import com.togetherhana.game.dto.request.GameCreateRequestDto;
 import com.togetherhana.game.dto.request.OptionChoiceRequestDto;
-import com.togetherhana.game.dto.response.GameParticipantDto;
 import com.togetherhana.game.dto.response.GameSelectResponseDto;
 import com.togetherhana.game.service.GameService;
 

--- a/togetherHana/src/main/java/com/togetherhana/game/controller/GameController.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/controller/GameController.java
@@ -1,5 +1,7 @@
 package com.togetherhana.game.controller;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -9,6 +11,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.togetherhana.base.BaseResponse;
 import com.togetherhana.game.dto.request.GameCreateRequestDto;
 import com.togetherhana.game.dto.request.OptionChoiceRequestDto;
+import com.togetherhana.game.dto.response.GameParticipantDto;
+import com.togetherhana.game.dto.response.GameSelectResponseDto;
 import com.togetherhana.game.service.GameService;
 
 import lombok.RequiredArgsConstructor;
@@ -34,9 +38,20 @@ public class GameController {
 		/**
 		 * 추후 수정
 		 */
-		Long memberId = 1L;
-		gameService.vote(memberId, optionChoiceRequestDto);
+		Long memberIdx = 1L;
+		gameService.vote(memberIdx, optionChoiceRequestDto);
 		return BaseResponse.success();
+	}
+
+	@PostMapping("/game/select")
+	public BaseResponse decideGameWinner(@RequestBody OptionChoiceRequestDto optionChoiceRequestDto) {
+
+		/**
+		 * 추후 수정
+		 */
+		Long memberIdx = 2L;
+		GameSelectResponseDto gameSelectResponseDto = gameService.decideGameWinner(memberIdx, optionChoiceRequestDto);
+		return BaseResponse.success(gameSelectResponseDto);
 	}
 
 }

--- a/togetherHana/src/main/java/com/togetherhana/game/dto/response/GameParticipantDto.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/dto/response/GameParticipantDto.java
@@ -1,0 +1,17 @@
+package com.togetherhana.game.dto.response;
+
+import com.togetherhana.member.entity.Member;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GameParticipantDto {
+	private String nickname;
+
+	public static GameParticipantDto of(Member member) {
+		return new GameParticipantDto(member.getNickname());
+	}
+}

--- a/togetherHana/src/main/java/com/togetherhana/game/dto/response/GameSelectResponseDto.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/dto/response/GameSelectResponseDto.java
@@ -1,0 +1,18 @@
+package com.togetherhana.game.dto.response;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GameSelectResponseDto {
+		String gameTitle;
+		List<GameParticipantDto> losers;
+
+		public static GameSelectResponseDto of(String gameTitle, List<GameParticipantDto> losers) {
+			return new GameSelectResponseDto(gameTitle, losers);
+		}
+}

--- a/togetherHana/src/main/java/com/togetherhana/game/dto/response/GameSelectResponseDto.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/dto/response/GameSelectResponseDto.java
@@ -10,9 +10,9 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GameSelectResponseDto {
 		String gameTitle;
-		List<GameParticipantDto> losers;
+		List<MemberDto> losers;
 
-		public static GameSelectResponseDto of(String gameTitle, List<GameParticipantDto> losers) {
+		public static GameSelectResponseDto of(String gameTitle, List<MemberDto> losers) {
 			return new GameSelectResponseDto(gameTitle, losers);
 		}
 }

--- a/togetherHana/src/main/java/com/togetherhana/game/dto/response/MemberDto.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/dto/response/MemberDto.java
@@ -8,10 +8,10 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class GameParticipantDto {
+public class MemberDto {
 	private String nickname;
 
-	public static GameParticipantDto of(Member member) {
-		return new GameParticipantDto(member.getNickname());
+	public static MemberDto of(Member member) {
+		return new MemberDto(member.getNickname());
 	}
 }

--- a/togetherHana/src/main/java/com/togetherhana/game/entity/Game.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/entity/Game.java
@@ -49,4 +49,8 @@ public class Game extends BaseEntity {
         this.sharingAccount = sharingAccount;
         this.isPlaying = Boolean.TRUE;
     }
+
+    public void endGame() {
+        this.isPlaying = Boolean.FALSE;
+    }
 }

--- a/togetherHana/src/main/java/com/togetherhana/game/entity/GameParticipant.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/entity/GameParticipant.java
@@ -46,4 +46,8 @@ public class GameParticipant extends BaseEntity {
         this.game = game;
         this.isWinner = Boolean.FALSE;
     }
+
+    public void setWinner() {
+        this.isWinner = Boolean.TRUE;
+    }
 }

--- a/togetherHana/src/main/java/com/togetherhana/game/repository/GameParticipantRepository.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/repository/GameParticipantRepository.java
@@ -1,8 +1,13 @@
 package com.togetherhana.game.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.togetherhana.game.entity.Game;
 import com.togetherhana.game.entity.GameParticipant;
 
 public interface GameParticipantRepository extends JpaRepository<GameParticipant, Long> {
+
+	List<GameParticipant> findByGame(Game game);
 }

--- a/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
@@ -143,13 +143,15 @@ public class GameService {
 		Long gameOptionIdx)
 	{
 		List<GameParticipant> loserParticipants = new ArrayList<>();
-		for (GameParticipant gameParticipant : gameParticipants) {
+
+		gameParticipants.forEach(gameParticipant -> {
 			if (gameParticipant.getGameOption().getGameOptionIdx().equals(gameOptionIdx)) {
 				gameParticipant.setWinner();
 			} else {
 				loserParticipants.add(gameParticipant);
 			}
-		}
+		});
+
 		return loserParticipants;
 	}
 

--- a/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
@@ -111,14 +111,26 @@ public class GameService {
 
 		Game game = findGameById(optionChoiceRequestDto.getGameIdx());
 
+		verifyIsLeader(game.getSharingAccount(), memberIdx);
+
 		List<GameParticipant> gameParticipants = gameParticipantRepository.findByGame(game);
 
 		List<GameParticipant> loserParticipants = decideWinnerAndLosers(gameParticipants, optionChoiceRequestDto.getGameOptionIdx());
 		List<Member> loserMembers = toLoserMembers(loserParticipants);
 
 		game.endGame();
+
 		return createGameSelectResponseDto(game, loserMembers);
 
+	}
+
+	private void verifyIsLeader(SharingAccount sharingAccount, Long memberIdx) {
+		SharingMember sharingMember = sharingMemberService.findBySharingAccountAndMemberIdx(
+			sharingAccount, memberIdx);
+
+		if(sharingMember.getIsLeader().equals(Boolean.FALSE)) {
+			throw new BaseException(LEADER_PRIVILEGES_REQUIRED);
+		}
 	}
 
 	private Game findGameById(Long gameId) {

--- a/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
@@ -154,12 +154,9 @@ public class GameService {
 	}
 
 	private List<Member> toLoserMembers(List<GameParticipant> loserParticipants) {
-		List<Member> loserMembers = new ArrayList<>();
-		for (GameParticipant gameParticipant : loserParticipants) {
-			Member member = gameParticipant.getSharingMember().getMember();
-			loserMembers.add(member);
-		}
-		return loserMembers;
+		return loserParticipants.stream()
+			.map(gameParticipant -> gameParticipant.getSharingMember().getMember())
+			.collect(Collectors.toList());
 	}
 
 	private GameSelectResponseDto createGameSelectResponseDto(Game game, List<Member> loserMembers) {

--- a/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
@@ -4,6 +4,7 @@ import static com.togetherhana.exception.ErrorType.*;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -14,12 +15,15 @@ import com.togetherhana.exception.BaseException;
 import com.togetherhana.game.dto.GameOptionDto;
 import com.togetherhana.game.dto.request.GameCreateRequestDto;
 import com.togetherhana.game.dto.request.OptionChoiceRequestDto;
+import com.togetherhana.game.dto.response.GameParticipantDto;
+import com.togetherhana.game.dto.response.GameSelectResponseDto;
 import com.togetherhana.game.entity.Game;
 import com.togetherhana.game.entity.GameOption;
 import com.togetherhana.game.entity.GameParticipant;
 import com.togetherhana.game.repository.GameOptionRepository;
 import com.togetherhana.game.repository.GameParticipantRepository;
 import com.togetherhana.game.repository.GameRepository;
+import com.togetherhana.member.entity.Member;
 import com.togetherhana.sharingAccount.entity.SharingAccount;
 import com.togetherhana.sharingAccount.entity.SharingMember;
 import com.togetherhana.sharingAccount.service.SharingAccountService;
@@ -73,8 +77,7 @@ public class GameService {
 
 	@Transactional
 	public void vote(Long memberIdx, OptionChoiceRequestDto optionChoiceRequestDto) {
-		Game game = gameRepository.findById(optionChoiceRequestDto.getGameIdx())
-			.orElseThrow(() -> new BaseException(GAME_NOT_FOUND));
+		Game game = findGameById(optionChoiceRequestDto.getGameIdx());
 
 		verifyIsDeadLinePassed(game.getDeadline());
 		
@@ -101,6 +104,58 @@ public class GameService {
 		if (now.isAfter(deadline)) {
 			throw new BaseException(IS_DEADLINE_PASSED);
 		}
+	}
+
+	@Transactional
+	public GameSelectResponseDto decideGameWinner(Long memberIdx, OptionChoiceRequestDto optionChoiceRequestDto) {
+
+		Game game = findGameById(optionChoiceRequestDto.getGameIdx());
+
+		List<GameParticipant> gameParticipants = gameParticipantRepository.findByGame(game);
+
+		List<GameParticipant> loserParticipants = decideWinnerAndLosers(gameParticipants, optionChoiceRequestDto.getGameOptionIdx());
+		List<Member> loserMembers = toLoserMembers(loserParticipants);
+
+		game.endGame();
+		return createGameSelectResponseDto(game, loserMembers);
+
+	}
+
+	private Game findGameById(Long gameId) {
+		return gameRepository.findById(gameId)
+			.orElseThrow(() -> new BaseException(GAME_NOT_FOUND));
+	}
+
+	private List<GameParticipant> decideWinnerAndLosers(
+		List<GameParticipant> gameParticipants,
+		Long gameOptionIdx)
+	{
+		List<GameParticipant> loserParticipants = new ArrayList<>();
+		for (GameParticipant gameParticipant : gameParticipants) {
+			if (gameParticipant.getGameOption().getGameOptionIdx().equals(gameOptionIdx)) {
+				gameParticipant.setWinner();
+			} else {
+				loserParticipants.add(gameParticipant);
+			}
+		}
+		return loserParticipants;
+	}
+
+	private List<Member> toLoserMembers(List<GameParticipant> loserParticipants) {
+		List<Member> loserMembers = new ArrayList<>();
+		for (GameParticipant gameParticipant : loserParticipants) {
+			Member member = gameParticipant.getSharingMember().getMember();
+			loserMembers.add(member);
+		}
+		return loserMembers;
+	}
+
+	private GameSelectResponseDto createGameSelectResponseDto(Game game, List<Member> loserMembers) {
+		List<GameParticipantDto> gameParticipantDtos = loserMembers.stream()
+			.map(GameParticipantDto::of)
+			.collect(Collectors.toList());
+
+		return GameSelectResponseDto.of(game.getGameTitle(), gameParticipantDtos);
 	}
 
 }

--- a/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
@@ -15,7 +15,7 @@ import com.togetherhana.exception.BaseException;
 import com.togetherhana.game.dto.GameOptionDto;
 import com.togetherhana.game.dto.request.GameCreateRequestDto;
 import com.togetherhana.game.dto.request.OptionChoiceRequestDto;
-import com.togetherhana.game.dto.response.GameParticipantDto;
+import com.togetherhana.game.dto.response.MemberDto;
 import com.togetherhana.game.dto.response.GameSelectResponseDto;
 import com.togetherhana.game.entity.Game;
 import com.togetherhana.game.entity.GameOption;
@@ -162,11 +162,11 @@ public class GameService {
 	}
 
 	private GameSelectResponseDto createGameSelectResponseDto(Game game, List<Member> loserMembers) {
-		List<GameParticipantDto> gameParticipantDtos = loserMembers.stream()
-			.map(GameParticipantDto::of)
+		List<MemberDto> memberDtos = loserMembers.stream()
+			.map(MemberDto::of)
 			.collect(Collectors.toList());
 
-		return GameSelectResponseDto.of(game.getGameTitle(), gameParticipantDtos);
+		return GameSelectResponseDto.of(game.getGameTitle(), memberDtos);
 	}
 
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #13 

## 🔑 Key Changes

1. 승리호 결정 시 게임 완료 처리 및 참여자들 승패 결정
2. 총무만 가능하도록 권한 처리
3. 응답으로 패배자들 정보 리턴

## 📢 To Reviewers
- 
