### PR TITLE
FCM 푸시알림 기능 구현, 모임통장 초대장 생성 및 합류 기능구현

### DIFF
--- a/togetherHana/src/main/java/com/togetherhana/exception/ErrorType.java
+++ b/togetherHana/src/main/java/com/togetherhana/exception/ErrorType.java
@@ -27,7 +27,8 @@ public enum ErrorType {
 	ALREADY_MYTEAM_PICKED(HttpStatus.BAD_REQUEST, "이미 응원팀을 설정했습니다."),
 
 	NOT_ENOUGH_MILEAGE_AMOUNT(HttpStatus.BAD_REQUEST, "마일리지 잔액이 부족합니다."),
-
+	WRONG_INVITATION_CODE(HttpStatus.BAD_REQUEST, "일치하는 초대코드가 없습니다."),
+	NOT_COINCIDE_INVITATION(HttpStatus.BAD_REQUEST, "초대장 코드와 가입하려는 모임통장이 일치하지 않습니다."),
 
 	/**
 	 * 401 UNAUTHROZIED

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/controller/InvitationController.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/controller/InvitationController.java
@@ -1,0 +1,40 @@
+package com.togetherhana.sharingAccount.controller;
+
+import com.togetherhana.auth.jwt.Auth;
+import com.togetherhana.base.BaseResponse;
+import com.togetherhana.member.entity.Member;
+import com.togetherhana.sharingAccount.dto.ParticipateRequest;
+import com.togetherhana.sharingAccount.dto.SharingAccountResponse;
+import com.togetherhana.sharingAccount.service.InvitationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/invite")
+public class InvitationController {
+    private final InvitationService invitationService;
+
+    @GetMapping("/code")
+    public BaseResponse<String> inviteCode(@RequestParam(name = "sharingAccountIdx") Long sharingAccountIdx) {
+        return BaseResponse.success(invitationService.createInvitationCode(sharingAccountIdx));
+    }
+
+    @GetMapping("/info")
+    public BaseResponse<SharingAccountResponse> inviteInfo(@RequestParam("invitationCode") String invitationCode) {
+        return BaseResponse.success(invitationService.getInvitationInfo(invitationCode));
+    }
+
+    @PostMapping("/participate")
+    public BaseResponse<Boolean> participate(@Auth Member member, @RequestBody ParticipateRequest participateRequest)
+    {
+        return BaseResponse.success(invitationService.participate(member, participateRequest));
+    }
+}

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/controller/SharingAccountController.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/controller/SharingAccountController.java
@@ -8,6 +8,7 @@ import com.togetherhana.sharingAccount.dto.SharingAccountCreateRequest;
 import com.togetherhana.sharingAccount.dto.SharingAccountCreateResponse;
 import com.togetherhana.sharingAccount.dto.SharingAccountResponse;
 import com.togetherhana.sharingAccount.dto.SharingMemberResponse;
+import com.togetherhana.sharingAccount.dto.TaxCollectRequest;
 import com.togetherhana.sharingAccount.service.SharingAccountService;
 import com.togetherhana.transfer.dto.TransferRequest;
 import com.togetherhana.transfer.dto.TransferResponse;
@@ -61,6 +62,11 @@ public class SharingAccountController {
     @PostMapping("/withdraw")
     public BaseResponse<Boolean> withdrawMoney(@Auth Member member, @RequestBody TransferRequest transferRequest) {
         return BaseResponse.success(transferService.withdraw(member, transferRequest));
+    }
+
+    @PostMapping("/collect")
+    public BaseResponse<Boolean> collectMoney(@Auth Member member, @RequestBody TaxCollectRequest taxCollectRequest) {
+        return BaseResponse.success(sharingAccountService.collectMoney(member, taxCollectRequest));
     }
 
 }

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/controller/SharingAccountController.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/controller/SharingAccountController.java
@@ -4,6 +4,7 @@ import com.togetherhana.auth.jwt.Auth;
 import com.togetherhana.base.BaseResponse;
 import com.togetherhana.member.entity.Member;
 import com.togetherhana.member.repository.MemberRepository;
+import com.togetherhana.sharingAccount.dto.ParticipateRequest;
 import com.togetherhana.sharingAccount.dto.SharingAccountCreateRequest;
 import com.togetherhana.sharingAccount.dto.SharingAccountCreateResponse;
 import com.togetherhana.sharingAccount.dto.SharingAccountResponse;

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/controller/SharingAccountController.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/controller/SharingAccountController.java
@@ -29,10 +29,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/sharing-account")
 public class SharingAccountController {
     private final SharingAccountService sharingAccountService;
-    /**
-     * memberRepo 의존성은 나중에 삭제
-     */
-    private final MemberRepository memberRepository;
     private final TransferService transferService;
 
     @PostMapping("/create")

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/dto/ParticipateRequest.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/dto/ParticipateRequest.java
@@ -1,0 +1,13 @@
+package com.togetherhana.sharingAccount.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ParticipateRequest {
+    private Long sharingAccountIdx;
+    private String invitationCode;
+}

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/dto/SharingAccountResponse.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/dto/SharingAccountResponse.java
@@ -1,9 +1,10 @@
 package com.togetherhana.sharingAccount.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.togetherhana.sharingAccount.entity.SharingAccount;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,7 +14,9 @@ import lombok.NoArgsConstructor;
 public class SharingAccountResponse {
     private Long sharingAccountIdx;
     private String accountName;
+    @JsonInclude(Include.NON_NULL)
     private String accountNumber;
+    @JsonInclude(Include.NON_NULL)
     private Long remainBalance;
 
     public static SharingAccountResponse of(SharingAccount account) {
@@ -21,6 +24,13 @@ public class SharingAccountResponse {
                 account.getSharingAccountName(),
                 String.valueOf(account.getSharingAccountNumber()),
                 account.getRemainBalance());
+    }
+
+    public static SharingAccountResponse invitation(SharingAccount account) {
+        return new SharingAccountResponse(account.getSharingAccountIdx(),
+                account.getSharingAccountName(),
+                null,
+                null);
     }
 
 }

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/dto/SharingMemberResponse.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/dto/SharingMemberResponse.java
@@ -1,15 +1,25 @@
 package com.togetherhana.sharingAccount.dto;
 
+import com.togetherhana.base.SportsType;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class SharingMemberResponse {
     private Long memberIdx;
     private String memberNickName;
     private String imageUrl;
     private Boolean isLeader;
+    private Optional<SportsType> sportsType;
+
+    public SharingMemberResponse(Long memberIdx, String memberNickName, String imageUrl, Boolean isLeader, SportsType sportsType) {
+        this.memberIdx = memberIdx;
+        this.memberNickName = memberNickName;
+        this.imageUrl = imageUrl;
+        this.isLeader = isLeader;
+        this.sportsType = Optional.ofNullable(sportsType);
+    }
 }

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/dto/TaxCollectRequest.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/dto/TaxCollectRequest.java
@@ -1,0 +1,13 @@
+package com.togetherhana.sharingAccount.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TaxCollectRequest {
+    private Long sharingAccountId;
+    private Integer collectingAmount;
+}

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/repository/CustomSharingMemberRepositoryImpl.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/repository/CustomSharingMemberRepositoryImpl.java
@@ -24,14 +24,15 @@ public class CustomSharingMemberRepositoryImpl implements CustomSharingMemberRep
                         member.memberIdx,
                         member.nickname,
                         sportsClub.imgUrl,
-                        sharingMember.isLeader
+                        sharingMember.isLeader,
+                        sportsClub.type
                 ))
                 .from(member)
-                .join(myTeam)
+                .leftJoin(myTeam)
                 .on(myTeam.member.memberIdx.eq(member.memberIdx))
-                .join(sportsClub)
+                .leftJoin(sportsClub)
                 .on(sportsClub.sportsClubIdx.eq(myTeam.sportsClub.sportsClubIdx))
-                .join(sharingMember)
+                .leftJoin(sharingMember)
                 .on(sharingMember.member.memberIdx.eq(member.memberIdx))
                 .where(sharingMember.sharingAccount.sharingAccountIdx.eq(sharingAccountIdx))
                 .fetch();

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/repository/SharingMemberRepository.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/repository/SharingMemberRepository.java
@@ -1,5 +1,6 @@
 package com.togetherhana.sharingAccount.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.togetherhana.sharingAccount.entity.SharingMember;
@@ -9,5 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface SharingMemberRepository extends JpaRepository<SharingMember, Long>, CustomSharingMemberRepository {
   
   Optional<SharingMember> findBySharingAccount_SharingAccountIdxAndMember_MemberIdx(Long sharingAccountIdx, Long memberIdx);
+  List<SharingMember> findBySharingAccount_SharingAccountIdx(Long sharingAccountIdx);
 }
 

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/service/InvitationService.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/service/InvitationService.java
@@ -1,0 +1,78 @@
+package com.togetherhana.sharingAccount.service;
+
+import com.togetherhana.exception.BaseException;
+import com.togetherhana.exception.ErrorType;
+import com.togetherhana.member.entity.Member;
+import com.togetherhana.sharingAccount.dto.ParticipateRequest;
+import com.togetherhana.sharingAccount.dto.SharingAccountResponse;
+import com.togetherhana.sharingAccount.entity.SharingAccount;
+import com.togetherhana.sharingAccount.entity.SharingMember;
+import com.togetherhana.sharingAccount.repository.SharingAccountRepository;
+import com.togetherhana.sharingAccount.repository.SharingMemberRepository;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InvitationService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final SharingAccountRepository sharingAccountRepository;
+    private final SharingMemberRepository sharingMemberRepository;
+
+    public String createInvitationCode(Long sharingAccountIdx) {
+        String uuid = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(uuid, sharingAccountIdx.toString(),30, TimeUnit.MINUTES);
+        return uuid;
+    }
+
+    public SharingAccountResponse getInvitationInfo(String invitationCode) {
+        Object value = redisTemplate.opsForValue().get(invitationCode);
+        if (value == null) {
+            throw new BaseException(ErrorType.WRONG_INVITATION_CODE);
+        }
+        Long sharingAccountIdx = Long.parseLong((String) value);
+        SharingAccount sharingAccount = sharingAccountRepository.findById(sharingAccountIdx).orElseThrow(
+                () -> new BaseException(ErrorType.SHARING_ACCOUNT_NOT_FOUND)
+        );
+        return SharingAccountResponse.invitation(sharingAccount);
+    }
+
+    @Transactional
+    public boolean participate(Member member, ParticipateRequest participateRequest) {
+        verifyIsRightInvitationCode(participateRequest);
+        SharingAccount sharingAccount = sharingAccountRepository.findById(participateRequest.getSharingAccountIdx())
+                .orElseThrow(
+                        () -> new BaseException(ErrorType.SHARING_ACCOUNT_NOT_FOUND)
+                );
+
+        SharingMember sharingMember = SharingMember.builder()
+                .member(member)
+                .sharingAccount(sharingAccount)
+                .isLeader(Boolean.FALSE)
+                .build();
+        try {
+            sharingMemberRepository.save(sharingMember);
+            redisTemplate.expire(participateRequest.getInvitationCode(), 1, TimeUnit.SECONDS);
+        } catch (DataIntegrityViolationException e) {
+            throw new BaseException(ErrorType.INTERNAL_SERVER);
+        }
+        return Boolean.TRUE;
+    }
+
+    private void verifyIsRightInvitationCode(ParticipateRequest participateRequest) {
+        Object o = redisTemplate.opsForValue().get(participateRequest.getInvitationCode());
+        if (o == null) {
+            throw new BaseException(ErrorType.WRONG_INVITATION_CODE);
+        }
+        Long sharingAccountIdx = Long.parseLong((String) o);
+        if (!sharingAccountIdx.equals(participateRequest.getSharingAccountIdx())) {
+            throw new BaseException(ErrorType.NOT_COINCIDE_INVITATION);
+        }
+    }
+}

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/service/SharingAccountService.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/service/SharingAccountService.java
@@ -1,22 +1,29 @@
 package com.togetherhana.sharingAccount.service;
 
+import static com.togetherhana.exception.ErrorType.BAD_REQUEST;
 import static com.togetherhana.exception.ErrorType.LEADER_PRIVILEGES_REQUIRED;
 import static com.togetherhana.exception.ErrorType.SHARING_MEMBER_NOT_FOUND;
 
 import com.togetherhana.base.SportsType;
 import com.togetherhana.exception.BaseException;
 import com.togetherhana.exception.ErrorType;
+import com.togetherhana.member.entity.DeviceInfo;
 import com.togetherhana.member.entity.Member;
+import com.togetherhana.notification.event.NotificationEvent;
+import com.togetherhana.notification.service.NotificationService;
 import com.togetherhana.sharingAccount.dto.SharingAccountCreateRequest;
 import com.togetherhana.sharingAccount.dto.SharingAccountCreateResponse;
 import com.togetherhana.sharingAccount.dto.SharingAccountResponse;
 import com.togetherhana.sharingAccount.dto.SharingMemberResponse;
+import com.togetherhana.sharingAccount.dto.TaxCollectRequest;
 import com.togetherhana.sharingAccount.entity.SharingAccount;
 import com.togetherhana.sharingAccount.entity.SharingMember;
 import com.togetherhana.sharingAccount.repository.SharingAccountRepository;
 import com.togetherhana.sharingAccount.repository.SharingMemberRepository;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -29,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SharingAccountService {
     private final SharingAccountRepository sharingAccountRepository;
     private final SharingMemberRepository sharingMemberRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public SharingAccountCreateResponse createAccount(Member member, SharingAccountCreateRequest createRequest) {
@@ -51,7 +59,7 @@ public class SharingAccountService {
             return new SharingAccountCreateResponse(save.getSharingAccountNumber().toString(),
                     save.getSharingAccountName(), member.getName(), save.getCreatedAt());
         } catch (DataIntegrityViolationException e) {
-            throw new BaseException(ErrorType.BAD_REQUEST);
+            throw new BaseException(BAD_REQUEST);
         }
     }
 
@@ -62,7 +70,8 @@ public class SharingAccountService {
     }
 
     public SharingMember findBySharingAccountAndMemberIdx(Long sharingAccountIdx, Long memberIdx) {
-        return sharingMemberRepository.findBySharingAccount_SharingAccountIdxAndMember_MemberIdx(sharingAccountIdx, memberIdx)
+        return sharingMemberRepository.findBySharingAccount_SharingAccountIdxAndMember_MemberIdx(sharingAccountIdx,
+                        memberIdx)
                 .orElseThrow(() -> new BaseException(SHARING_MEMBER_NOT_FOUND));
     }
 
@@ -75,8 +84,34 @@ public class SharingAccountService {
         return sharingMemberRepository.findSharingMemberWithTeam(sharingAccountIdx);
     }
 
+    public Boolean collectMoney(Member member, TaxCollectRequest taxCollectRequest) {
+        verifyIsLeader(taxCollectRequest.getSharingAccountId(), member.getMemberIdx());
+
+        List<SharingMember> sharingMembers = sharingMemberRepository.findBySharingAccount_SharingAccountIdx(
+                taxCollectRequest.getSharingAccountId());
+
+        List<Integer> perMoney = calculatePerMoney(taxCollectRequest.getCollectingAmount(), sharingMembers.size());
+
+        sendMoneyNotification(perMoney, sharingMembers);
+        return Boolean.TRUE;
+    }
+
+    private void sendMoneyNotification(List<Integer> perMoney, List<SharingMember> sharingMembers) {
+        for (int i = 0; i < perMoney.size(); i++) {
+            for (DeviceInfo deviceInfo : sharingMembers.get(i).getMember().getDeviceInfos()) {
+
+                NotificationEvent event = NotificationEvent.builder()
+                        .title("회비 걷기 요청이 왔어요 !")
+                        .body("입금 요청 금액은 " + String.format("%,d", perMoney.get(i)) + "원 입니다.")
+                        .deviceToken(deviceInfo.getDeviceToken()).build();
+                notificationService.publishPushEvent(event);
+            }
+        }
+    }
+
     public void verifyIsLeader(Long sharingAccountIdx, Long memberIdx) {
-        SharingMember sharingMember = sharingMemberRepository.findBySharingAccount_SharingAccountIdxAndMember_MemberIdx(sharingAccountIdx,
+        SharingMember sharingMember = sharingMemberRepository.findBySharingAccount_SharingAccountIdxAndMember_MemberIdx(
+                        sharingAccountIdx,
                         memberIdx)
                 .orElseThrow(() -> new BaseException(SHARING_MEMBER_NOT_FOUND));
 
@@ -85,6 +120,23 @@ public class SharingAccountService {
         }
     }
 
+    private List<Integer> calculatePerMoney(int amount, int personnel) {
+        if (personnel == 0) {
+            throw new BaseException(BAD_REQUEST);
+        }
+
+        int baseAmount = amount / personnel;
+        int reminder = amount % personnel;
+
+        int[] perMoney = new int[personnel];
+        Arrays.fill(perMoney, baseAmount);
+
+        for (int i = 0; i < reminder; i++) {
+            perMoney[personnel - 1 - i]++;
+        }
+
+        return Arrays.stream(perMoney).boxed().collect(Collectors.toList());
+    }
 
     private Long createAccountNumber() {
         Random random = new Random();

--- a/togetherHana/src/main/java/com/togetherhana/sharingAccount/service/SharingAccountService.java
+++ b/togetherHana/src/main/java/com/togetherhana/sharingAccount/service/SharingAccountService.java
@@ -81,7 +81,14 @@ public class SharingAccountService {
     }
 
     public List<SharingMemberResponse> findSharingMemberInfo(Long sharingAccountIdx) {
-        return sharingMemberRepository.findSharingMemberWithTeam(sharingAccountIdx);
+        SharingAccount sharingAccount = sharingAccountRepository.findById(sharingAccountIdx)
+                .orElseThrow(() -> new BaseException(ErrorType.SHARING_ACCOUNT_NOT_FOUND));
+
+        return sharingMemberRepository.findSharingMemberWithTeam(sharingAccountIdx)
+                .stream()
+                .filter(sharingMemberResponse -> sharingMemberResponse.getSportsType().isEmpty() ||
+                                sharingMemberResponse.getSportsType().get().equals(sharingAccount.getSharePurpose())
+                        ).collect(Collectors.toList());
     }
 
     public Boolean collectMoney(Member member, TaxCollectRequest taxCollectRequest) {

--- a/togetherHana/src/main/java/com/togetherhana/transfer/dto/TransferResponse.java
+++ b/togetherHana/src/main/java/com/togetherhana/transfer/dto/TransferResponse.java
@@ -1,48 +1,40 @@
 package com.togetherhana.transfer.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.togetherhana.transfer.entity.TransactionType;
 import com.togetherhana.transfer.entity.TransferHistory;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 
 @Getter
-public abstract class TransferResponse {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TransferResponse {
 
     private Long remainBalance;
     private Long transactionAmount;
     private TransactionType transferType;
+    @JsonInclude(Include.NON_NULL)
+    private String sender;
+    @JsonInclude(Include.NON_NULL)
+    private String recipient;
 
-    private TransferResponse(TransferHistory transferHistory) {
-        this.remainBalance = transferHistory.getRemainBalance();
-        this.transactionAmount = transferHistory.getTransactionAmount();
-        this.transferType = transferHistory.getTransferType();
-
+    public static TransferResponse toDepositResponse(TransferHistory transferHistory) {
+        return new TransferResponse(transferHistory.getRemainBalance(),
+                transferHistory.getTransactionAmount(),
+                transferHistory.getTransferType(),
+                transferHistory.getSender(),
+                null);
     }
 
-    public static class DepositResponse extends TransferResponse {
-        private String sender;
-
-        private DepositResponse(TransferHistory transferHistory) {
-            super(transferHistory);
-            this.sender = transferHistory.getSender();
-        }
-
-        public static DepositResponse of(TransferHistory transferHistory) {
-            return new DepositResponse(transferHistory);
-        }
-    }
-
-    public static class WithdrawalResponse extends TransferResponse {
-        private String recipient;
-
-        private WithdrawalResponse(TransferHistory transferHistory) {
-            super(transferHistory);
-            this.recipient = transferHistory.getRecipient();
-        }
-
-        public static WithdrawalResponse of(TransferHistory transferHistory) {
-            return new WithdrawalResponse(transferHistory);
-        }
+    public static TransferResponse toWithdrawResponse(TransferHistory transferHistory) {
+        return new TransferResponse(transferHistory.getRemainBalance(),
+                transferHistory.getTransactionAmount(),
+                transferHistory.getTransferType(),
+                null,
+                transferHistory.getRecipient());
     }
 
 }

--- a/togetherHana/src/main/java/com/togetherhana/transfer/service/TransferService.java
+++ b/togetherHana/src/main/java/com/togetherhana/transfer/service/TransferService.java
@@ -4,17 +4,13 @@ import com.togetherhana.exception.BaseException;
 import com.togetherhana.exception.ErrorType;
 import com.togetherhana.member.entity.Member;
 import com.togetherhana.sharingAccount.entity.SharingAccount;
-import com.togetherhana.sharingAccount.entity.SharingMember;
 import com.togetherhana.sharingAccount.service.SharingAccountService;
 import com.togetherhana.transfer.dto.TransferRequest;
 import com.togetherhana.transfer.dto.TransferResponse;
-import com.togetherhana.transfer.dto.TransferResponse.DepositResponse;
-import com.togetherhana.transfer.dto.TransferResponse.WithdrawalResponse;
 import com.togetherhana.transfer.entity.TransactionType;
 import com.togetherhana.transfer.entity.TransferHistory;
 import com.togetherhana.transfer.repository.TransferRepository;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,9 +29,9 @@ public class TransferService {
 
         return transferHistories.stream().map(transferHistory -> {
             if (transferHistory.getTransferType().equals(TransactionType.DEPOSIT)) {
-                return DepositResponse.of(transferHistory);
+                return TransferResponse.toDepositResponse(transferHistory);
             }
-            return WithdrawalResponse.of(transferHistory);
+            return TransferResponse.toWithdrawResponse(transferHistory);
         }).toList();
     }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #30 

## 🔑 Key Changes

1. 회비걷기 푸시 알림 기능 구현
2. 모임통장 초대장 생성 기능 구현(feat. Redis)
3. 모임통장 합류 기능 구현(feat. Redis)
4. 서비스에 가입되어 있는 유저인지 아닌지 확인하는 로직

Error 해결
- 응원팀 설정안한 멤버가 모임통장 멤버에 조회되지 않는 예외 해결
- 이체내역에서 받는사람, 보내는사람 정보가 나타나지 않는 예외 해결

## 📢 To Reviewers
- 
