### PR TITLE
승리팀 맞추기 이벤트 기능 구현

### DIFF
--- a/togetherHana/src/main/java/com/togetherhana/auth/service/AuthService.java
+++ b/togetherHana/src/main/java/com/togetherhana/auth/service/AuthService.java
@@ -89,7 +89,7 @@ public class AuthService {
 
         // 새로운 토큰 생성
         return generateJwtToken(memberRepository.findById(userId)
-                .orElseThrow(() -> new BaseException(ErrorType.INVAILD_MEMBER_IDX)));
+                .orElseThrow(() -> new BaseException(ErrorType.INVALID_MEMBER_IDX)));
 
     }
 }

--- a/togetherHana/src/main/java/com/togetherhana/config/AsyncConfig.java
+++ b/togetherHana/src/main/java/com/togetherhana/config/AsyncConfig.java
@@ -27,4 +27,13 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean("eventConcludeExecutor")
+    public TaskExecutor getEventConcludeExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setThreadNamePrefix("TogetherHana-Event-Thread: ");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/togetherHana/src/main/java/com/togetherhana/config/JwtArgumentResolver.java
+++ b/togetherHana/src/main/java/com/togetherhana/config/JwtArgumentResolver.java
@@ -37,7 +37,7 @@ public class JwtArgumentResolver implements HandlerMethodArgumentResolver {
         String token = JwtTokenExtractor.extractJwt(request);
 
         Long memberIdx = jwtTokenProvider.getMemberIdxFromToken(token);
-        return memberRepository.findById(memberIdx).orElseThrow(() -> new BaseException(ErrorType.INVAILD_MEMBER_IDX));
+        return memberRepository.findById(memberIdx).orElseThrow(() -> new BaseException(ErrorType.INVALID_MEMBER_IDX));
 
     }
 }

--- a/togetherHana/src/main/java/com/togetherhana/config/SchedulerConfig.java
+++ b/togetherHana/src/main/java/com/togetherhana/config/SchedulerConfig.java
@@ -1,0 +1,16 @@
+package com.togetherhana.config;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SchedulerConfig {
+
+    @Bean
+    public ScheduledExecutorService scheduledExecutorService() {
+        return Executors.newScheduledThreadPool(1);
+    }
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/controller/EventController.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/controller/EventController.java
@@ -1,0 +1,45 @@
+package com.togetherhana.event.predict.controller;
+
+import com.togetherhana.auth.jwt.Auth;
+import com.togetherhana.base.BaseResponse;
+import com.togetherhana.event.predict.dto.EventConcludeRequest;
+import com.togetherhana.event.predict.dto.EventGameCreateRequest;
+import com.togetherhana.event.predict.dto.EventGameInfoResponse;
+import com.togetherhana.event.predict.dto.PredictionRequest;
+import com.togetherhana.event.predict.service.EventGameService;
+import com.togetherhana.member.entity.Member;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/event")
+public class EventController {
+    private final EventGameService eventGameService;
+
+    @GetMapping("/list")
+    public BaseResponse<List<EventGameInfoResponse>> eventList() {
+        return BaseResponse.success(eventGameService.allEventGames());
+    }
+
+    @PostMapping("/pick")
+    public BaseResponse<Boolean> pick(@Auth Member member, @RequestBody PredictionRequest predictionRequest) {
+        return BaseResponse.success(eventGameService.pickWinnerTeam(member, predictionRequest));
+    }
+
+    @PostMapping("/create")
+    public BaseResponse<Boolean> create(@RequestBody EventGameCreateRequest eventGameCreateRequest) {
+        return BaseResponse.success(eventGameService.createEventGame(eventGameCreateRequest));
+    }
+
+    @PostMapping("/conclude")
+    public BaseResponse<Boolean> conclude(@RequestBody EventConcludeRequest eventConcludeRequest) {
+        return BaseResponse.success(eventGameService.concludeEventGame(eventConcludeRequest));
+    }
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/dto/EventConcludeRequest.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/dto/EventConcludeRequest.java
@@ -1,0 +1,14 @@
+package com.togetherhana.event.predict.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class EventConcludeRequest {
+    private Long eventGameIdx;
+    private Long winningTeamIdx;
+    private Integer amount;
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/dto/EventGameCreateRequest.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/dto/EventGameCreateRequest.java
@@ -1,0 +1,23 @@
+package com.togetherhana.event.predict.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class EventGameCreateRequest {
+    private String title;
+    private String location;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDay;
+    @DateTimeFormat(pattern = "kk:mm:ss")
+    private LocalTime startTime;
+    private Long homeTeamIdx;
+    private Long awayTeamIdx;
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/dto/EventGameInfoResponse.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/dto/EventGameInfoResponse.java
@@ -1,0 +1,40 @@
+package com.togetherhana.event.predict.dto;
+
+import com.togetherhana.event.predict.entity.EventGame;
+import com.togetherhana.sportClub.entity.SportsClub;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class EventGameInfoResponse {
+    private Long eventGameIdx;
+    private String eventTitle;
+    private LocalDateTime eventStartTime;
+    private String eventLocation;
+    private boolean isDone;
+
+    private TeamInfo home;
+    private TeamInfo away;
+
+    public EventGameInfoResponse(EventGame eventGame, SportsClub home, SportsClub away) {
+        this.eventGameIdx = eventGame.getIdx();
+        this.eventTitle = eventGame.getTitle();
+        this.eventStartTime = eventGame.getStartTime();
+        this.eventLocation = eventGame.getLocation();
+        this.isDone = eventGame.getIsDone();
+        this.home = new TeamInfo(home.getName(), home.getSportsClubIdx(), home.getImgUrl());
+        this.away = new TeamInfo(away.getName(), away.getSportsClubIdx(), away.getImgUrl());
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class TeamInfo {
+        private String teamName;
+        private Long teamId;
+        private String teamImg;
+    }
+}
+

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/dto/PredictionRequest.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/dto/PredictionRequest.java
@@ -1,0 +1,13 @@
+package com.togetherhana.event.predict.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PredictionRequest {
+    private Long eventGameIdx;
+    private Long winnerPredictTeamIdx;
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/entity/EventGame.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/entity/EventGame.java
@@ -1,0 +1,41 @@
+package com.togetherhana.event.predict.entity;
+
+import com.togetherhana.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventGame extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_game_idx")
+    private Long idx;
+
+    private Long homeTeamIdx;
+    private Long awayTeamIdx;
+    private String title;
+    private LocalDateTime startTime;
+    private String location;
+    private Long winnerTeamIdx;
+    private Boolean isDone;
+
+    public void closeGame() {
+        this.isDone = Boolean.TRUE;
+    }
+    public void winner(Long winnerTeam) {
+        this.winnerTeamIdx = winnerTeam;
+    }
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/entity/Prediction.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/entity/Prediction.java
@@ -1,0 +1,37 @@
+package com.togetherhana.event.predict.entity;
+
+import com.togetherhana.base.BaseEntity;
+import com.togetherhana.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class Prediction extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "event_game_idx")
+    private EventGame eventGame;
+    @ManyToOne
+    @JoinColumn(name = "member_idx")
+    private Member member;
+
+    private Long predictTeamIdx;
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/repository/EventGameRepository.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/repository/EventGameRepository.java
@@ -1,0 +1,7 @@
+package com.togetherhana.event.predict.repository;
+
+import com.togetherhana.event.predict.entity.EventGame;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventGameRepository extends JpaRepository<EventGame, Long> {
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/repository/PredictionRepository.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/repository/PredictionRepository.java
@@ -1,0 +1,13 @@
+package com.togetherhana.event.predict.repository;
+
+import com.togetherhana.event.predict.entity.EventGame;
+import com.togetherhana.event.predict.entity.Prediction;
+import com.togetherhana.member.entity.Member;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PredictionRepository extends JpaRepository<Prediction, Long> {
+    boolean existsByMemberAndEventGame(Member member, EventGame eventGame);
+
+    List<Prediction> findByEventGameAndPredictTeamIdx(EventGame eventGame, Long predictTeamIdx);
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/service/EventGameConcludeEvent.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/service/EventGameConcludeEvent.java
@@ -1,0 +1,17 @@
+package com.togetherhana.event.predict.service;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class EventGameConcludeEvent {
+    private Long winner;
+    private int prizeAmount;
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/service/EventGameListener.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/service/EventGameListener.java
@@ -1,0 +1,43 @@
+package com.togetherhana.event.predict.service;
+
+import com.togetherhana.event.predict.entity.EventGame;
+import com.togetherhana.event.predict.repository.EventGameRepository;
+import com.togetherhana.exception.BaseException;
+import com.togetherhana.exception.ErrorType;
+import com.togetherhana.member.entity.Member;
+import com.togetherhana.member.repository.MemberRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class EventGameListener {
+
+    private final EventGameRepository eventGameRepository;
+    private final MemberRepository memberRepository;
+
+    @EventListener
+    @Transactional
+    protected void close(EventGameStartEvent event) {
+        EventGame eventGame = eventGameRepository.findById(event.getEventGameIdx()).get();
+        log.info("이벤트 게임 : {}이 시작되었습니다. 이벤트 참가를 종료합니다.", eventGame.getTitle());
+        eventGame.closeGame();
+    }
+
+    @EventListener
+    @Transactional
+    @Async("eventConcludeExecutor")
+    protected void conclude(EventGameConcludeEvent event) {
+        Member winningMember = memberRepository.findById(event.getWinner()).orElseThrow(
+                () -> new BaseException(ErrorType.INVALID_MEMBER_IDX)
+        );
+        log.info("{} 님에게 마일리지 {}를 지급합니다.", winningMember.getName(), event.getPrizeAmount());
+        winningMember.getMileage().plus(event.getPrizeAmount());
+    }
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/service/EventGameService.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/service/EventGameService.java
@@ -1,0 +1,127 @@
+package com.togetherhana.event.predict.service;
+
+import com.togetherhana.event.predict.dto.EventConcludeRequest;
+import com.togetherhana.event.predict.dto.EventGameCreateRequest;
+import com.togetherhana.event.predict.dto.EventGameInfoResponse;
+import com.togetherhana.event.predict.dto.PredictionRequest;
+import com.togetherhana.event.predict.entity.EventGame;
+import com.togetherhana.event.predict.entity.Prediction;
+import com.togetherhana.event.predict.repository.EventGameRepository;
+import com.togetherhana.event.predict.repository.PredictionRepository;
+import com.togetherhana.exception.BaseException;
+import com.togetherhana.exception.ErrorType;
+import com.togetherhana.member.entity.Member;
+import com.togetherhana.sportClub.entity.SportsClub;
+import com.togetherhana.sportClub.repository.SportsClubRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EventGameService {
+    private final EventGameRepository eventGameRepository;
+    private final SportsClubRepository sportsClubRepository;
+    private final PredictionRepository predictionRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final ScheduledExecutorService scheduledExecutorService;
+
+    @Transactional
+    public Boolean createEventGame(EventGameCreateRequest eventGameCreateRequest) {
+        EventGame eventGame = EventGame.builder()
+                .title(eventGameCreateRequest.getTitle())
+                .location(eventGameCreateRequest.getLocation())
+                .startTime(
+                        LocalDateTime.of(eventGameCreateRequest.getStartDay(), eventGameCreateRequest.getStartTime()))
+                .homeTeamIdx(eventGameCreateRequest.getHomeTeamIdx())
+                .awayTeamIdx(eventGameCreateRequest.getAwayTeamIdx())
+                .isDone(Boolean.FALSE)
+                .build();
+        eventGameRepository.save(eventGame);
+        long delay = Date.from(eventGame.getStartTime().atZone(ZoneId.systemDefault()).toInstant()).getTime() -
+                Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant()).getTime();
+
+        scheduledExecutorService.schedule(() -> applicationEventPublisher.publishEvent(
+                EventGameStartEvent.builder().eventGameIdx(eventGame.getIdx()).build()), delay, TimeUnit.MILLISECONDS);
+        return Boolean.TRUE;
+    }
+
+
+    public List<EventGameInfoResponse> allEventGames() {
+        List<EventGame> eventGames = eventGameRepository.findAll();
+        return eventGames.stream().filter(eventGame -> eventGame.getIsDone().equals(Boolean.FALSE))
+                .map(eventGame -> {
+                    SportsClub home = sportsClubRepository.findById(eventGame.getHomeTeamIdx())
+                            .orElseThrow(() -> new BaseException(ErrorType.NO_SPORTSCLUB_INFO));
+                    SportsClub away = sportsClubRepository.findById(eventGame.getAwayTeamIdx())
+                            .orElseThrow(() -> new BaseException(ErrorType.NO_SPORTSCLUB_INFO));
+
+                    return new EventGameInfoResponse(eventGame, home, away);
+                }).toList();
+    }
+
+    @Transactional
+    public Boolean concludeEventGame(EventConcludeRequest eventConcludeRequest) {
+
+        EventGame eventGame = eventGameRepository.findById(eventConcludeRequest.getEventGameIdx()).orElseThrow(
+                () -> new BaseException(ErrorType.EVENT_NOT_FOUND)
+        );
+        eventGame.winner(eventConcludeRequest.getWinningTeamIdx());
+
+        List<Long> winners = findWinner(eventGame, eventConcludeRequest.getWinningTeamIdx());
+        for (Long winner : winners) {
+            giveMileageTo(winner, eventConcludeRequest.getAmount());
+        }
+        return Boolean.TRUE;
+    }
+
+    private void giveMileageTo(Long winner, int amount) {
+        applicationEventPublisher.publishEvent(EventGameConcludeEvent.builder()
+                .winner(winner)
+                .prizeAmount(amount).build());
+    }
+
+    private List<Long> findWinner(EventGame eventGame, Long winningTeamIdx) {
+        List<Prediction> predictions = predictionRepository.findByEventGameAndPredictTeamIdx(eventGame,
+                winningTeamIdx);
+        return predictions.stream().map(prediction -> prediction.getMember().getMemberIdx()).toList();
+    }
+
+    @Transactional
+    public Boolean pickWinnerTeam(Member member, PredictionRequest predictionRequest) {
+        EventGame eventGame = eventGameRepository.findById(predictionRequest.getEventGameIdx()).orElseThrow(
+                () -> new BaseException(ErrorType.EVENT_NOT_FOUND)
+        );
+        verifyAlreadyPick(member, eventGame);
+        verifyIsDone(eventGame);
+        Prediction prediction = Prediction.builder()
+                .eventGame(eventGame)
+                .member(member)
+                .predictTeamIdx(predictionRequest.getWinnerPredictTeamIdx())
+                .build();
+
+        predictionRepository.save(prediction);
+        return Boolean.TRUE;
+    }
+
+    private void verifyIsDone(EventGame eventGame) {
+        if (eventGame.getIsDone()) {
+            throw new BaseException(ErrorType.ALREADY_START);
+        }
+    }
+
+    private void verifyAlreadyPick(Member member, EventGame eventGame) {
+        if (predictionRepository.existsByMemberAndEventGame(member, eventGame)) {
+            throw new BaseException(ErrorType.ALREADY_PICK);
+        }
+    }
+}

--- a/togetherHana/src/main/java/com/togetherhana/event/predict/service/EventGameStartEvent.java
+++ b/togetherHana/src/main/java/com/togetherhana/event/predict/service/EventGameStartEvent.java
@@ -1,0 +1,15 @@
+package com.togetherhana.event.predict.service;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class EventGameStartEvent {
+    private Long eventGameIdx;
+}

--- a/togetherHana/src/main/java/com/togetherhana/exception/ErrorType.java
+++ b/togetherHana/src/main/java/com/togetherhana/exception/ErrorType.java
@@ -29,6 +29,8 @@ public enum ErrorType {
 	NOT_ENOUGH_MILEAGE_AMOUNT(HttpStatus.BAD_REQUEST, "마일리지 잔액이 부족합니다."),
 	WRONG_INVITATION_CODE(HttpStatus.BAD_REQUEST, "일치하는 초대코드가 없습니다."),
 	NOT_COINCIDE_INVITATION(HttpStatus.BAD_REQUEST, "초대장 코드와 가입하려는 모임통장이 일치하지 않습니다."),
+	ALREADY_PICK(HttpStatus.BAD_REQUEST, "이미 참여한 이벤트입니다."),
+	ALREADY_START(HttpStatus.BAD_REQUEST, "이미 경기가 시작하였습니다."),
 
 	/**
 	 * 401 UNAUTHROZIED
@@ -49,12 +51,13 @@ public enum ErrorType {
 	 */
 	NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리소스입니다."),
 	NO_SPORTSCLUB_INFO(HttpStatus.NOT_FOUND, "구단 정보가 존재하지 않습니다."),
-	INVAILD_MEMBER_IDX(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다."),
+	INVALID_MEMBER_IDX(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다."),
 	MEMBER_BY_DEVICE_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "멤버 정보를 찾을 수 없습니다."),
 	SHARING_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모임통장이 존재하지 않습니다."),
 	SHARING_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모임원이 존재하지 않습니다."),
 	GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게임이 존재하지 않습니다."),
 	GAME_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게임선택지가 존재하지 않습니다."),
+	EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이벤트가 존재하지 않습니다."),
 
 	INVAILD_MILEAGE_IDX(HttpStatus.NOT_FOUND, "마일리지 정보를 찾을 수 없습니다."),
 	/**

--- a/togetherHana/src/main/java/com/togetherhana/member/dto/SignUpRequest.java
+++ b/togetherHana/src/main/java/com/togetherhana/member/dto/SignUpRequest.java
@@ -21,4 +21,6 @@ public class SignUpRequest {
 
     private String address;
 
+    private String fcmToken;
+
 }

--- a/togetherHana/src/main/java/com/togetherhana/member/repository/DeviceInfoRepository.java
+++ b/togetherHana/src/main/java/com/togetherhana/member/repository/DeviceInfoRepository.java
@@ -1,0 +1,7 @@
+package com.togetherhana.member.repository;
+
+import com.togetherhana.member.entity.DeviceInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeviceInfoRepository extends JpaRepository<DeviceInfo, Long> {
+}

--- a/togetherHana/src/main/java/com/togetherhana/member/repository/MemberRepository.java
+++ b/togetherHana/src/main/java/com/togetherhana/member/repository/MemberRepository.java
@@ -1,6 +1,8 @@
 package com.togetherhana.member.repository;
 
 import com.togetherhana.member.entity.Member;
+import java.util.Collection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +18,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Member findByPhoneNumberAndName(String phoneNumber, String name);
     Member findByMemberIdx(Long memberIdx);
+
 }

--- a/togetherHana/src/main/java/com/togetherhana/member/service/MemberService.java
+++ b/togetherHana/src/main/java/com/togetherhana/member/service/MemberService.java
@@ -4,7 +4,9 @@ import com.togetherhana.exception.BaseException;
 import com.togetherhana.exception.ErrorType;
 import com.togetherhana.member.dto.MyInfoResponse;
 import com.togetherhana.member.dto.SignUpRequest;
+import com.togetherhana.member.entity.DeviceInfo;
 import com.togetherhana.member.entity.Member;
+import com.togetherhana.member.repository.DeviceInfoRepository;
 import com.togetherhana.member.repository.MemberRepository;
 import com.togetherhana.mileage.entity.Mileage;
 import com.togetherhana.mileage.repository.MileageRepository;
@@ -24,6 +26,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MileageRepository mileageRepository;
     private final MyteamRepository myteamRepository;
+    private final DeviceInfoRepository deviceInfoRepository;
 
     @Transactional
     public Long saveMember(SignUpRequest signUpRequest) {
@@ -42,20 +45,25 @@ public class MemberService {
                 .mileage(mileage)
                 .build();
         Member savedMember = memberRepository.save(member);
+        deviceInfoRepository.save(DeviceInfo.builder()
+                .deviceToken(signUpRequest.getFcmToken())
+                .member(savedMember).build());
+
         return savedMember.getMemberIdx();
 
     }
 
     public void joinedMemberCheck(SignUpRequest signUpRequest) {
-        Member member = memberRepository.findByPhoneNumberAndName(signUpRequest.getPhoneNumber(), signUpRequest.getName());
-        if(member != null) {
+        Member member = memberRepository.findByPhoneNumberAndName(signUpRequest.getPhoneNumber(),
+                signUpRequest.getName());
+        if (member != null) {
             throw new BaseException(ErrorType.JOINED_MEMBER);
         }
     }
 
-    public Member getMemberByDeviceToken(String deviceToken){
+    public Member getMemberByDeviceToken(String deviceToken) {
         Member member = memberRepository.findByDeviceToken(deviceToken);
-        if(member == null) {
+        if (member == null) {
             throw new BaseException(ErrorType.MEMBER_BY_DEVICE_TOKEN_NOT_FOUND);
         }
         return member;
@@ -64,7 +72,7 @@ public class MemberService {
     // 닉네임 중복 체크
     public Boolean nicknameDuplicationCheck(String nickname) {
         Member member = memberRepository.findByNickname(nickname);
-        if(member != null) {
+        if (member != null) {
             return true;
         }
         return false;
@@ -73,12 +81,12 @@ public class MemberService {
     // 내정보 조회(마일리지, 응원팀, 닉네임) - 메인 화면
     public MyInfoResponse getMyInfoByMemberIdx(Long memberIdx) {
 
-       Member member = memberRepository.findById(memberIdx)
-               .orElseThrow(() -> new BaseException(ErrorType.INVAILD_MEMBER_IDX));
-       //log.info("마일리지 잔액 : "+ member.getMileage().getAmount());
+        Member member = memberRepository.findById(memberIdx)
+                .orElseThrow(() -> new BaseException(ErrorType.INVALID_MEMBER_IDX));
+        //log.info("마일리지 잔액 : "+ member.getMileage().getAmount());
 
-       List<MyTeam> myTeamList = myteamRepository.findByMember_MemberIdx(memberIdx);
+        List<MyTeam> myTeamList = myteamRepository.findByMember_MemberIdx(memberIdx);
 
-       return new MyInfoResponse(member,myTeamList);
+        return new MyInfoResponse(member, myTeamList);
     }
 }

--- a/togetherHana/src/main/java/com/togetherhana/mileage/entity/Mileage.java
+++ b/togetherHana/src/main/java/com/togetherhana/mileage/entity/Mileage.java
@@ -7,8 +7,8 @@ import com.togetherhana.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Entity(name="mileage")
-@Table(name="mileage")
+@Entity(name = "mileage")
+@Table(name = "mileage")
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
@@ -17,7 +17,7 @@ public class Mileage extends BaseEntity {
 
     // 마일리지 아이디
     @Id
-    @GeneratedValue(strategy=GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mileage_idx")
     private Long mileageIdx;
 
@@ -29,5 +29,9 @@ public class Mileage extends BaseEntity {
             throw new BaseException(ErrorType.NOT_ENOUGH_MILEAGE_AMOUNT);
         }
         return amount -= usedAmount;
+    }
+
+    public long plus(long amount) {
+        return this.amount += amount;
     }
 }

--- a/togetherHana/src/main/java/com/togetherhana/transfer/dto/TransferResponse.java
+++ b/togetherHana/src/main/java/com/togetherhana/transfer/dto/TransferResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.togetherhana.transfer.entity.TransactionType;
 import com.togetherhana.transfer.entity.TransferHistory;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,13 +21,15 @@ public class TransferResponse {
     private String sender;
     @JsonInclude(Include.NON_NULL)
     private String recipient;
+    private LocalDateTime createdAt;
 
     public static TransferResponse toDepositResponse(TransferHistory transferHistory) {
         return new TransferResponse(transferHistory.getRemainBalance(),
                 transferHistory.getTransactionAmount(),
                 transferHistory.getTransferType(),
                 transferHistory.getSender(),
-                null);
+                null,
+                transferHistory.getCreatedAt());
     }
 
     public static TransferResponse toWithdrawResponse(TransferHistory transferHistory) {
@@ -34,7 +37,8 @@ public class TransferResponse {
                 transferHistory.getTransactionAmount(),
                 transferHistory.getTransferType(),
                 null,
-                transferHistory.getRecipient());
+                transferHistory.getRecipient(),
+                transferHistory.getCreatedAt());
     }
 
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #35 

## 🔑 Key Changes

1. 승리팀 맞추기 이벤트 기능 구현 완료
2. 이벤트 경기 생성, 조회, 승리팀 결정, 참가 기능 구현
3. 이벤트 경기는 이벤트 경기 시작 시 자동으로 종료됨(참가불가❌)
4. 이벤트 경기의 승리팀이 결정되면, 예측에 성공한 참가자들에게 마일리지가 지급됨 (관리자 API 생성완료)
5. 이체 내역에 이체가 발생한 날짜가 반환되도록 수정
6. 회원가입 시 fcmToken을 전달받아 DeviceInfo를 생성하도록 수정

## 📢 To Reviewers
- 
