### PR TITLE
매치 상세조회 응답 수정

### DIFF
--- a/togetherHana/src/main/java/com/togetherhana/game/dto/response/GameDetailResponseDto.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/dto/response/GameDetailResponseDto.java
@@ -3,6 +3,7 @@ package com.togetherhana.game.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.togetherhana.game.entity.Game;
 
@@ -15,6 +16,8 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 public class GameDetailResponseDto {
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private Long votedOptionIdx;
 	@JsonProperty("isVotingClosed")
 	private boolean votingClosed;
 	@JsonProperty("isVotingMember")
@@ -25,12 +28,14 @@ public class GameDetailResponseDto {
 	private List<GameOptionDto> gameOptionDtos;
 
 	public static GameDetailResponseDto of(
+		Long votedOptionIdx,
 		Boolean isVotingClosed,
 		Boolean isVotingMember,
 		Game game,
 		List<GameOptionDto> gameOptionDtos
 	) {
 		return GameDetailResponseDto.builder()
+			.votedOptionIdx(votedOptionIdx)
 			.votingClosed(isVotingClosed)
 			.votingMember(isVotingMember)
 			.gameTitle(game.getGameTitle())

--- a/togetherHana/src/main/java/com/togetherhana/game/entity/Game.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/entity/Game.java
@@ -34,7 +34,7 @@ public class Game extends BaseEntity {
     private Integer fine;
     private Boolean isPlaying;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sharing_account_idx")
     private SharingAccount sharingAccount;
 

--- a/togetherHana/src/main/java/com/togetherhana/game/repository/CustomGameRepository.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/repository/CustomGameRepository.java
@@ -3,10 +3,13 @@ import java.util.List;
 import java.util.Optional;
 
 import com.togetherhana.game.entity.Game;
+import com.togetherhana.game.entity.GameParticipant;
 
 public interface CustomGameRepository {
 
-	Optional<Game> findGameDetailByGameIdx(Long gameIdx);
+	Optional<Game> findGameWithOptions(Long gameIdx);
+
+	List<GameParticipant> findParticipantsByGameIdx(Long gameIdx);
 
 	List<Game> findGameHistoryBySharingAccountIdx(Long sharingAccountIdx);
 }

--- a/togetherHana/src/main/java/com/togetherhana/game/repository/CustomGameRepositoryImpl.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/repository/CustomGameRepositoryImpl.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.togetherhana.game.entity.Game;
+import com.togetherhana.game.entity.GameParticipant;
+import com.togetherhana.game.entity.QGame;
 
 import static com.togetherhana.game.entity.QGame.game;
 import static com.togetherhana.game.entity.QGameOption.gameOption;
@@ -23,18 +25,23 @@ public class CustomGameRepositoryImpl implements CustomGameRepository {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Optional<Game> findGameDetailByGameIdx(Long gameIdx) {
-
-		Game finedGame = queryFactory
-			.selectFrom(game)
-			.leftJoin(game.gameParticipants, gameParticipant).fetchJoin()
-			.leftJoin(gameParticipant.gameOption, gameOption).fetchJoin()
-			.leftJoin(gameParticipant.sharingMember, sharingMember).fetchJoin()
-			.leftJoin(sharingMember.member, member).fetchJoin()
-			.where(game.id.eq(gameIdx))
+	public Optional<Game> findGameWithOptions(Long gameIdx) {
+		Game game = queryFactory.selectFrom(QGame.game)
+			.leftJoin(QGame.game.gameOptions, gameOption).fetchJoin()
+			.where(QGame.game.id.eq(gameIdx))
+			.distinct()
 			.fetchOne();
 
-		return Optional.ofNullable(finedGame);
+		return Optional.ofNullable(game);
+	}
+
+	@Override
+	public List<GameParticipant> findParticipantsByGameIdx(Long gameIdx) {
+		return queryFactory.selectFrom(gameParticipant)
+			.leftJoin(gameParticipant.sharingMember, sharingMember).fetchJoin()
+			.leftJoin(sharingMember.member, member).fetchJoin()
+			.where(gameParticipant.game.id.eq(gameIdx))
+			.fetch();
 	}
 
 	@Override

--- a/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
+++ b/togetherHana/src/main/java/com/togetherhana/game/service/GameService.java
@@ -126,8 +126,6 @@ public class GameService {
 
 	}
 
-
-
 	private Game findGameById(Long gameId) {
 		return gameRepository.findById(gameId)
 			.orElseThrow(() -> new BaseException(GAME_NOT_FOUND));
@@ -173,6 +171,8 @@ public class GameService {
 		boolean isVotingMember = game.getGameParticipants().stream()
 			.anyMatch(participant -> participant.getSharingMember().getMember().getMemberIdx().equals(memberIdx));
 
+		Long votedOptionIdx = findVotedOptionIdx(game, memberIdx);
+
 		List<GameOption> gameOptions = game.getGameOptions();
 
 		List<GameOptionDto> gameOptionDtos = gameOptions.stream()
@@ -185,7 +185,15 @@ public class GameService {
 			})
 			.collect(Collectors.toList());
 
-		return GameDetailResponseDto.of(isVotingClosed, isVotingMember, game, gameOptionDtos);
+		return GameDetailResponseDto.of(votedOptionIdx, isVotingClosed, isVotingMember, game, gameOptionDtos);
+	}
+
+	private Long findVotedOptionIdx(Game game, Long memberIdx) {
+		return game.getGameParticipants().stream()
+			.filter(participant -> participant.getSharingMember().getMember().getMemberIdx().equals(memberIdx))
+			.findFirst()
+			.map(participant -> participant.getGameOption().getGameOptionIdx())
+			.orElse(null);
 	}
 
 	public GameHistoryResponseDto getGameHistoryAndCurrentGame(Long sharingAccountIdx) {


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #44 

## 🔑 Key Changes

1. 매치 상세조회 응답을 수정합니다. 투표를 한 멤버라면 어떤 옵션에 투표했는지 추가로 리턴합니다.

## 📢 To Reviewers
- 
